### PR TITLE
Fix: Finding JLinkExe on macOS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+## 0.13.1 - 2025-09-15
+
+### Fixed
+
+-   On macOS `/usr/local/bin` is not in `$PATH` by default but this is where
+    `JLinkExe` is placed by the SEGGER J-Link installer. Even if one configures
+    shells to include `/usr/local/bin` in `$PATH`, that usually doesn't take
+    effect for GUI apps, so we must add it manually.
+
 ## 0.13.0 - 2025-09-11
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/nrf-jlink-js",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "main": "dist",
     "types": "dist",
     "files": [

--- a/src/shared/jLinkVersion.ts
+++ b/src/shared/jLinkVersion.ts
@@ -73,11 +73,22 @@ export const isValidVersion = (
         convertToSemverVersion(expectedVersion)
     );
 
+const getEnv = () => {
+    if (process.platform !== 'darwin') return undefined;
+
+    return {
+        ...process.env,
+        PATH: `${process.env.PATH}:/usr/local/bin`
+    };
+}
+
 export const getInstalledJLinkVersion = async (): Promise<string> => {
     using scriptFile = createTemporaryScriptFile('Exit');
 
     const output = await promisify(exec)(
-        `${getJLinkExePath()} -CommandFile ${scriptFile.filePath}`
+        `${getJLinkExePath()} -CommandFile ${scriptFile.filePath}`, {
+            env: getEnv()
+    }
     ).catch(e => e);
 
     const versionRegExp = /^SEGGER J-Link Commander V([0-9a-z.]+) .*$/m;


### PR DESCRIPTION
Fixes [NCD-1460](https://nordicsemi.atlassian.net/browse/NCD-1460):

On macOS `/usr/local/bin` is not in `$PATH` by default but this is where `JLinkExe` is placed by the SEGGER J-Link installer. Even if one configures shells to include `/usr/local/bin` in `$PATH`, that usually doesn't take effect for GUI apps, so we must add it manually.