### PR TITLE
Add `getHostFirmwareVersions` and `isDebugProbeFirmwareUpdateAvailable`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+## 0.14.0 - 2025-10-02
+
+### Added
+
+-   `getHostFirmwareVersions` to extract available debug probe firmware
+    information from a given JLink installation
+-   `isDebugProbeFirmwareUpdateAvailable` to check whether a newer firmware is
+    available for a given debug probe
+
 ## 0.13.1 - 2025-09-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/nrf-jlink-js",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "main": "dist",
     "types": "dist",
     "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,7 @@ export type { Update as JLinkUpdate } from './shared/update';
 export { downloadAndInstallJLink, downloadAndSaveJLink } from './jlink';
 export { getJLinkState, type JLinkState } from './operations/getJLinkState';
 export { installJLink } from './operations/installJLink';
+export {
+    getHostFirmwareVersions,
+    isDebugProbeFirmwareUpdateAvailable,
+} from './operations/debugProbeFirmwares';

--- a/src/operations/debugProbeFirmwares.ts
+++ b/src/operations/debugProbeFirmwares.ts
@@ -56,17 +56,16 @@ export const getHostFirmwareVersions = (jlinkDir: string): HostFirmwares => {
  * Returns whether a debug probe firmware update is available for the given device
  * based on the host firmware versions.
  *
- * @param device The connected debug probe device as the device element returned by
+ * @param jlinkObFirmwareVersion The connected debug probe firmware version as returned by
  *         `nrfutil --json --skip-overhead device device-info --serial-number ${serialNumber}`
  * @param hostFirmwares The host firmware versions as returned by `getHostFirmwareVersions`
  * @returns `true` if an update is available, `false` if not, or `undefined` if the
  *          information is insufficient to determine this.
  */
 export const isDebugProbeFirmwareUpdateAvailable = (
-    device: NrfUtilDevice,
+    jlinkObFirmwareVersion: string,
     hostFirmwares: HostFirmwares
 ): boolean | undefined => {
-    const { jlinkObFirmwareVersion } = device.deviceInfo.jlink;
     const [deviceObFirmwareId, deviceObFirmwareDateStr] =
         jlinkObFirmwareVersion.split(' compiled ');
 

--- a/src/operations/debugProbeFirmwares.ts
+++ b/src/operations/debugProbeFirmwares.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { readdirSync, readSync, openSync, closeSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface HostFirmwareInfo {
+    filePath: string;
+    compiledOn: Date;
+}
+
+interface HostFirmwares {
+    [key: string]: HostFirmwareInfo;
+}
+
+interface NrfUtilDevice {
+    deviceInfo: { jlink: { jlinkObFirmwareVersion: string } };
+}
+
+/**
+ * Reads the debug probe firmware files in the given JLink directory and returns
+ * a map of their IDs and compilation dates.
+ */
+export const getHostFirmwareVersions = (jlinkDir: string): HostFirmwares => {
+    const buffer = Buffer.alloc(64);
+
+    return Object.fromEntries(
+        readdirSync(jlinkDir)
+            .map(file => {
+                const filePath = join(jlinkDir, file);
+                const fd = openSync(filePath, 'r');
+                readSync(fd, buffer, 0, buffer.length, 0);
+                const [id, dateStr] = buffer
+                    .toString()
+                    .split('\0')[0]!
+                    .split(' compiled ');
+                closeSync(fd);
+                return id && dateStr
+                    ? [
+                          id,
+                          <HostFirmwareInfo>{
+                              filePath,
+                              compiledOn: new Date(dateStr),
+                          },
+                      ]
+                    : undefined;
+            })
+            .filter(v => v !== undefined)
+    );
+};
+
+/**
+ * Returns whether a debug probe firmware update is available for the given device
+ * based on the host firmware versions.
+ *
+ * @param device The connected debug probe device as the device element returned by
+ *         `nrfutil --json --skip-overhead device device-info --serial-number ${serialNumber}`
+ * @param hostFirmwares The host firmware versions as returned by `getHostFirmwareVersions`
+ * @returns `true` if an update is available, `false` if not, or `undefined` if the
+ *          information is insufficient to determine this.
+ */
+export const isDebugProbeFirmwareUpdateAvailable = (
+    device: NrfUtilDevice,
+    hostFirmwares: HostFirmwares
+): boolean | undefined => {
+    const { jlinkObFirmwareVersion } = device.deviceInfo.jlink;
+    const [deviceObFirmwareId, deviceObFirmwareDateStr] =
+        jlinkObFirmwareVersion.split(' compiled ');
+
+    if (!deviceObFirmwareId || !deviceObFirmwareDateStr) {
+        // No date info in firmware version
+        return;
+    }
+    const hostFwDate = hostFirmwares[deviceObFirmwareId]?.compiledOn;
+    if (!hostFwDate) {
+        // No matching firmware found
+        return;
+    }
+
+    // Return true if host firmware is newer indicating an update is available
+    return hostFwDate > new Date(deviceObFirmwareDateStr);
+};

--- a/src/operations/debugProbeFirmwares.ts
+++ b/src/operations/debugProbeFirmwares.ts
@@ -28,9 +28,9 @@ export const getHostFirmwareVersions = (jlinkDir: string): HostFirmwares => {
     const buffer = Buffer.alloc(64);
 
     return Object.fromEntries(
-        readdirSync(jlinkDir)
+        readdirSync(join(jlinkDir, 'Firmwares'))
             .map(file => {
-                const filePath = join(jlinkDir, file);
+                const filePath = join(jlinkDir, 'Firmwares', file);
                 const fd = openSync(filePath, 'r');
                 readSync(fd, buffer, 0, buffer.length, 0);
                 const [id, dateStr] = buffer


### PR DESCRIPTION
These functions would allow us to indicate that a given connected device's OB firmware is recent enough for a given JLink installation. Subsequent workflows can be offered to the user to update e.g. `nrfutil device x-update-debug-probe-firmware`.

`node -e "console.log(require('.').getHostFirmwareVersions('/Applications/SEGGER/JLink'))"` gives you:
```
{
  'J-Link / Flasher ARM V5': {
    filePath: '/Applications/SEGGER/JLink/Firmwares/FlasherARM_V5.bin',
    compiledOn: 2025-02-28T09:22:57.000Z
  },
  'J-Link / Flasher ARM V5-1': {
    filePath: '/Applications/SEGGER/JLink/Firmwares/FlasherARM_V5_1.bin',
    compiledOn: 2025-02-28T09:23:28.000Z
  }
  ...
}
```