### PR TITLE
Remove unneeded statement

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -19,6 +19,5 @@ jobs:
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version: 24
-            - run: npm install --global npm@latest
             - run: npm ci
             - run: npm publish --access public


### PR DESCRIPTION
Before it was necessary to install the latest version of npm because the bundled versions didn't support trusted publishing yet. Now it is ok again to just use the version of npm that comes with Node. https://docs.npmjs.com/trusted-publishers#supported-cicd-providers