### PR TITLE
Improving security in the publishing workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -19,5 +19,6 @@ jobs:
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version: 24
+                  package-manager-cache: false # Recommended for security in publishing workflows, see https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc
             - run: npm ci
             - run: npm publish --access public


### PR DESCRIPTION
Following the recommendation in 
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc